### PR TITLE
Remove specifying email option in docker login command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   pre:
-    - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+    - docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   override:
     - docker pull kimh/build-image:latest || true


### PR DESCRIPTION
Flag --email has been deprecated, will be removed in 1.13.